### PR TITLE
Fix: Update Underwater Volume to be Local instead of Global

### DIFF
--- a/Assets/Level/Scenes/HelloWorldDemoScene.unity
+++ b/Assets/Level/Scenes/HelloWorldDemoScene.unity
@@ -13476,8 +13476,9 @@ GameObject:
   m_Component:
   - component: {fileID: 1100941530}
   - component: {fileID: 1100941529}
+  - component: {fileID: 1100941531}
   m_Layer: 0
-  m_Name: Water Global Volume
+  m_Name: Water Local Volume
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -13495,7 +13496,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_IsGlobal: 1
+  m_IsGlobal: 0
   priority: 1
   blendDistance: 0
   weight: 1
@@ -13509,12 +13510,33 @@ Transform:
   m_GameObject: {fileID: 1100941528}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.91441345, y: -3.0448933, z: 5.6566806}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: -3, y: 159, z: 464}
+  m_LocalScale: {x: 241.25307, y: 281.52863, z: 1054.5555}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1100941531
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100941528}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &1101781680
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/BurstAotSettings_StandaloneWindows.json
+++ b/ProjectSettings/BurstAotSettings_StandaloneWindows.json
@@ -1,16 +1,18 @@
 {
   "MonoBehaviour": {
-    "Version": 3,
+    "Version": 4,
     "EnableBurstCompilation": true,
     "EnableOptimisations": true,
     "EnableSafetyChecks": false,
     "EnableDebugInAllBuilds": false,
-    "UsePlatformSDKLinker": false,
+    "DebugDataKind": 0,
+    "EnableArmv9SecurityFeatures": false,
     "CpuMinTargetX32": 0,
     "CpuMaxTargetX32": 0,
     "CpuMinTargetX64": 0,
     "CpuMaxTargetX64": 0,
     "CpuTargetsX32": 6,
-    "CpuTargetsX64": 72
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
   }
 }


### PR DESCRIPTION
Changing the Volume from Global to Local fixed the crashing and the enormous consumption of memory. My guess: the global volume included the skybox, which is stretches infinitely.